### PR TITLE
fix: remove output from approveStep and fix fromString for executeScript

### DIFF
--- a/API.md
+++ b/API.md
@@ -1226,6 +1226,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/cdk-ssm-documents.AutomationDocument.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@cdklabs/cdk-ssm-documents.AutomationDocument.property.cfnDocument">cfnDocument</a></code> | <code>aws-cdk-lib.aws_ssm.CfnDocument</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.AutomationDocument.property.description">description</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.AutomationDocument.property.docInputs">docInputs</a></code> | <code><a href="#@cdklabs/cdk-ssm-documents.Input">Input</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.AutomationDocument.property.docOutputs">docOutputs</a></code> | <code><a href="#@cdklabs/cdk-ssm-documents.DocumentOutput">DocumentOutput</a>[]</code> | *No description.* |
@@ -1246,6 +1247,16 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `cfnDocument`<sup>Required</sup> <a name="cfnDocument" id="@cdklabs/cdk-ssm-documents.AutomationDocument.property.cfnDocument"></a>
+
+```typescript
+public readonly cfnDocument: CfnDocument;
+```
+
+- *Type:* aws-cdk-lib.aws_ssm.CfnDocument
 
 ---
 
@@ -2872,6 +2883,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/cdk-ssm-documents.CommandDocument.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@cdklabs/cdk-ssm-documents.CommandDocument.property.cfnDocument">cfnDocument</a></code> | <code>aws-cdk-lib.aws_ssm.CfnDocument</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.CommandDocument.property.description">description</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.CommandDocument.property.docInputs">docInputs</a></code> | <code><a href="#@cdklabs/cdk-ssm-documents.Input">Input</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.CommandDocument.property.docOutputs">docOutputs</a></code> | <code><a href="#@cdklabs/cdk-ssm-documents.DocumentOutput">DocumentOutput</a>[]</code> | *No description.* |
@@ -2892,6 +2904,16 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `cfnDocument`<sup>Required</sup> <a name="cfnDocument" id="@cdklabs/cdk-ssm-documents.CommandDocument.property.cfnDocument"></a>
+
+```typescript
+public readonly cfnDocument: CfnDocument;
+```
+
+- *Type:* aws-cdk-lib.aws_ssm.CfnDocument
 
 ---
 
@@ -13721,6 +13743,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/cdk-ssm-documents.SsmDocument.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@cdklabs/cdk-ssm-documents.SsmDocument.property.cfnDocument">cfnDocument</a></code> | <code>aws-cdk-lib.aws_ssm.CfnDocument</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.SsmDocument.property.description">description</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.SsmDocument.property.docInputs">docInputs</a></code> | <code><a href="#@cdklabs/cdk-ssm-documents.Input">Input</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.SsmDocument.property.docOutputs">docOutputs</a></code> | <code><a href="#@cdklabs/cdk-ssm-documents.DocumentOutput">DocumentOutput</a>[]</code> | *No description.* |
@@ -13740,6 +13763,16 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `cfnDocument`<sup>Required</sup> <a name="cfnDocument" id="@cdklabs/cdk-ssm-documents.SsmDocument.property.cfnDocument"></a>
+
+```typescript
+public readonly cfnDocument: CfnDocument;
+```
+
+- *Type:* aws-cdk-lib.aws_ssm.CfnDocument
 
 ---
 
@@ -14279,6 +14312,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/cdk-ssm-documents.TimedDocument.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@cdklabs/cdk-ssm-documents.TimedDocument.property.cfnDocument">cfnDocument</a></code> | <code>aws-cdk-lib.aws_ssm.CfnDocument</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.TimedDocument.property.description">description</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.TimedDocument.property.docInputs">docInputs</a></code> | <code><a href="#@cdklabs/cdk-ssm-documents.Input">Input</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.TimedDocument.property.docOutputs">docOutputs</a></code> | <code><a href="#@cdklabs/cdk-ssm-documents.DocumentOutput">DocumentOutput</a>[]</code> | *No description.* |
@@ -14299,6 +14333,16 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `cfnDocument`<sup>Required</sup> <a name="cfnDocument" id="@cdklabs/cdk-ssm-documents.TimedDocument.property.cfnDocument"></a>
+
+```typescript
+public readonly cfnDocument: CfnDocument;
+```
+
+- *Type:* aws-cdk-lib.aws_ssm.CfnDocument
 
 ---
 

--- a/src/document/ssm-document.ts
+++ b/src/document/ssm-document.ts
@@ -87,6 +87,7 @@ export abstract class SsmDocument extends Construct {
   readonly docOutputs: DocumentOutput[];
   readonly docInputs: Input[];
   readonly props: SsmDocumentProps;
+  readonly cfnDocument: CfnDocument;
 
   constructor(scope: Construct, id: string, props: SsmDocumentProps) {
     super(scope, id);
@@ -102,7 +103,7 @@ export abstract class SsmDocument extends Construct {
     }
     this.props = props;
     const isYaml = this.props.documentFormat == DocumentFormat.YAML;
-    new CfnDocument(this, 'Resource', {
+    this.cfnDocument = new CfnDocument(this, 'Resource', {
       ...this.props,
       ...{
         content: Lazy.any({

--- a/src/parent-steps/automation/approve-step.ts
+++ b/src/parent-steps/automation/approve-step.ts
@@ -82,12 +82,14 @@ export class ApproveStep extends AutomationStep {
   }
 
   public toSsmEntry(): Record<string, any> {
-    return super.prepareSsmEntry(pruneAndTransformRecord({
+    const entireEntry = super.prepareSsmEntry(pruneAndTransformRecord({
       Approvers: this.approvers,
       NotificationArn: this.notificationArn,
       Message: this.message,
       MinRequiredApprovals: this.minRequiredApprovals,
     }, x => x.print()));
+    const { outputs, ...newObj } = entireEntry;
+    return newObj;
   }
 
   /**

--- a/src/patterns/automation/string-step.ts
+++ b/src/patterns/automation/string-step.ts
@@ -125,9 +125,10 @@ export class StringStep extends CompositeAutomationStep {
         break;
       case 'aws:executeScript':
         const inputs: { [name: string]: IGenericVariable } = {};
-        Object.entries(restParams.InputPayload).forEach(([key, value]) => inputs[key] = this.toVariable(value as string));
+        Object.entries(restParams.InputPayload ?? {}).forEach(([key, value]) => inputs[key] = this.toVariable(value as string));
+        const handler = restParams.Handler ? (<string>restParams.Handler).replace('function.', '') : undefined;
         this.automationStep = new ExecuteScriptStep(this, props.name, {
-          language: ScriptLanguage.fromRuntime(restParams.Runtime, restParams.Handler),
+          language: ScriptLanguage.fromRuntime(restParams.Runtime, handler),
           inputPayload: inputs,
           code: ScriptCode.inline(restParams.Script),
           ...sharedProps,

--- a/test/parent-steps/automation/approve-step.test.ts
+++ b/test/parent-steps/automation/approve-step.test.ts
@@ -37,15 +37,6 @@ describe('ApproveStep', function() {
           Message: 'Approve this asap',
           NotificationArn: 'notify arn',
         },
-        outputs: [{
-          Type: 'String',
-          Name: 'ApprovalStatus',
-          Selector: '$.ApprovalStatus',
-        }, {
-          Type: 'MapList',
-          Name: 'ApproverDecisions',
-          Selector: '$.ApproverDecisions',
-        }],
       });
     });
   });

--- a/test/parent-steps/automation/execute-script-step.test.ts
+++ b/test/parent-steps/automation/execute-script-step.test.ts
@@ -6,9 +6,11 @@ import {
   DataTypeEnum,
   ExecuteScriptStep,
   PythonVersion,
-  ResponseCode, ScriptCode,
+  ResponseCode,
+  ScriptCode,
   ScriptLanguage,
   StringVariable,
+  StringStep,
 } from '../../../lib';
 
 describe('ExecuteScriptStep', function() {
@@ -154,6 +156,24 @@ describe('ExecuteScriptStep', function() {
             Type: 'String',
           },
         ],
+      });
+    });
+  });
+  describe('fromString', function() {
+    it('From string should parse back to object', function() {
+      StringStep.fromObject(new Stack(), {
+        name: 'executeHelloWorldScript',
+        action: 'aws:executeScript',
+        timeoutSeconds: 100,
+        maxAttempts: 1,
+        description: '## HelloWorldScriptExecution\nReturns the Echo input value.\n',
+        inputs: {
+          Script: '..script..',
+          Runtime: 'python3.6',
+        },
+        isEnd: true,
+        onFailure: 'Abort',
+        isCritical: true,
       });
     });
   });


### PR DESCRIPTION
3 Changes including:
1. ApproveStep was printing the outputs which are already implicitly returned which caused a failure when printing
2. ExecuteScriptStep has improved support for fromString
3. SsmDocuments now have a field "cfnDocument" to allow access to the underlying construct.