### PR TITLE
fix: change output of failed simulation to be empty obj

### DIFF
--- a/src/simulation/automation-step-simulation.ts
+++ b/src/simulation/automation-step-simulation.ts
@@ -172,7 +172,7 @@ export class AutomationStepSimulation {
         } else {
           return {
             responseCode: ResponseCode.FAILED,
-            outputs: [],
+            outputs: {},
             stackTrace: (error as Error).message + '\n' + (error as Error).stack,
             executedSteps: [this.step.name],
           };

--- a/test/parent-steps/automation/execute-script-step.test.ts
+++ b/test/parent-steps/automation/execute-script-step.test.ts
@@ -174,6 +174,13 @@ describe('ExecuteScriptStep', function() {
         isEnd: true,
         onFailure: 'Abort',
         isCritical: true,
+        outputs: [
+          {
+            Name: 'Echo',
+            Selector: '$.Payload.Echo',
+            Type: 'String',
+          },
+        ],
       });
     });
   });


### PR DESCRIPTION
Export to python tries to convert this list to obj which does not work. I do not see this issue in TS.