### PR TITLE
fix: use InputPayload for ssm entry of aws:invokeLambdaFunction

### DIFF
--- a/API.md
+++ b/API.md
@@ -9294,7 +9294,6 @@ new InvokeLambdaFunctionStep(scope: Construct, id: string, props: InvokeLambdaFu
 | <code><a href="#@cdklabs/cdk-ssm-documents.InvokeLambdaFunctionStep.addToDocument">addToDocument</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ssm-documents.InvokeLambdaFunctionStep.listUserOutputs">listUserOutputs</a></code> | Lists the outputs defined by the user for this step. |
 | <code><a href="#@cdklabs/cdk-ssm-documents.InvokeLambdaFunctionStep.variables">variables</a></code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-ssm-documents.InvokeLambdaFunctionStep.formatInputMap">formatInputMap</a></code> | *No description.* |
 
 ---
 
@@ -9354,12 +9353,6 @@ Lists the outputs defined by the user for this step.
 
 ```typescript
 public variables(): {[ key: string ]: any}
-```
-
-##### `formatInputMap` <a name="formatInputMap" id="@cdklabs/cdk-ssm-documents.InvokeLambdaFunctionStep.formatInputMap"></a>
-
-```typescript
-public formatInputMap(): {[ key: string ]: any}
 ```
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>

--- a/src/parent-steps/automation/invoke-lambda-function-step.ts
+++ b/src/parent-steps/automation/invoke-lambda-function-step.ts
@@ -106,14 +106,14 @@ export class InvokeLambdaFunctionStep extends AutomationStep {
     return super.prepareSsmEntry(entries);
   }
 
-  public formatInputMap(): Record<string, any> {
+  private formatInputMap(): Record<string, any> {
     return {
       FunctionName: this.functionName,
       Qualifier: this.qualifier,
       InvocationType: this.invocationType,
       LogType: this.logType,
       ClientContext: this.clientContext,
-      Payload: this.payload,
+      InputPayload: this.payload,
     };
   }
 }

--- a/src/simulation/automation/invoke-lambda-function-simulation.ts
+++ b/src/simulation/automation/invoke-lambda-function-simulation.ts
@@ -26,7 +26,7 @@ export class InvokeLambdaFunctionSimulation extends AutomationSimulationBase {
   }
 
   public executeStep(inputs: Record<string, any>): Record<string, any> {
-    const inputMap = this.invokeLambdaFunctionStep.formatInputMap();
+    const inputMap = this.formatInputMap();
     const stepInputs = pruneAndTransformRecord(inputMap, x => x.resolve(inputs));
     stepInputs.InvocationType = stepInputs.InvocationType ?? 'RequestResponse';
     stepInputs.LogType = stepInputs.LogType ?? 'Tail';
@@ -55,4 +55,15 @@ export class InvokeLambdaFunctionSimulation extends AutomationSimulationBase {
     };
   }
 
+  private formatInputMap(): Record<string, any> {
+    const step = this.invokeLambdaFunctionStep;
+    return {
+      FunctionName: step.functionName,
+      Qualifier: step.qualifier,
+      InvocationType: step.invocationType,
+      LogType: step.logType,
+      ClientContext: step.clientContext,
+      Payload: step.payload,
+    };
+  }
 }

--- a/test/parent-steps/automation/invoke-lambda-function-step.test.ts
+++ b/test/parent-steps/automation/invoke-lambda-function-step.test.ts
@@ -112,7 +112,7 @@ describe('InvokeLambdaFunctionStep', () => {
           InvocationType: 'type',
           LogType: 'none',
           ClientContext: 'context',
-          Payload: { a: 1 },
+          InputPayload: { a: 1 },
         },
         name: 'id2',
       });


### PR DESCRIPTION
Fixes #57 
aws:invokeLambdaFunction allows defining a JSON string input Payload or a StringMap version InputPayload.  CDK was incorrectly setting the user's StringMap to the Payload variable instead of InputPayload.