### PR TITLE
fix: replace jsonpath with jsonpath-plus to drop vulnerable underscore

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -142,7 +142,7 @@
       "type": "bundled"
     },
     {
-      "name": "jsonpath",
+      "name": "jsonpath-plus",
       "type": "bundled"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -344,13 +344,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=prod --filter=@aws-sdk/client-cloudformation,@aws-sdk/client-cloudwatch,@aws-sdk/client-ec2,@aws-sdk/client-iam,@aws-sdk/client-lambda,@aws-sdk/client-s3,@aws-sdk/client-sns,@aws-sdk/client-sqs,@aws-sdk/client-ssm,immutable,js-yaml,jsonpath,python-shell,synchronized-promise"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=prod --filter=@aws-sdk/client-cloudformation,@aws-sdk/client-cloudwatch,@aws-sdk/client-ec2,@aws-sdk/client-iam,@aws-sdk/client-lambda,@aws-sdk/client-s3,@aws-sdk/client-sns,@aws-sdk/client-sqs,@aws-sdk/client-ssm,immutable,js-yaml,jsonpath-plus,python-shell,synchronized-promise"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-sdk/client-cloudformation @aws-sdk/client-cloudwatch @aws-sdk/client-ec2 @aws-sdk/client-iam @aws-sdk/client-lambda @aws-sdk/client-s3 @aws-sdk/client-sns @aws-sdk/client-sqs @aws-sdk/client-ssm immutable js-yaml jsonpath python-shell synchronized-promise"
+          "exec": "yarn upgrade @aws-sdk/client-cloudformation @aws-sdk/client-cloudwatch @aws-sdk/client-ec2 @aws-sdk/client-iam @aws-sdk/client-lambda @aws-sdk/client-s3 @aws-sdk/client-sns @aws-sdk/client-sqs @aws-sdk/client-ssm immutable js-yaml jsonpath-plus python-shell synchronized-promise"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -26,7 +26,7 @@ const project = new CdklabsConstructLibrary({
     '@aws-sdk/client-sns',
     '@aws-sdk/client-sqs',
     '@aws-sdk/client-ssm',
-    'jsonpath',
+    'jsonpath-plus',
     'python-shell',
     'js-yaml',
     'immutable',

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@aws-sdk/client-ssm": "^3.1090.0",
     "immutable": "^4.3.9",
     "js-yaml": "^4.3.0",
-    "jsonpath": "^1.3.0",
+    "jsonpath-plus": "^10.4.0",
     "python-shell": "^3.0.1",
     "synchronized-promise": "^0.3.1"
   },
@@ -101,7 +101,7 @@
     "@aws-sdk/client-ssm",
     "immutable",
     "js-yaml",
-    "jsonpath",
+    "jsonpath-plus",
     "python-shell",
     "synchronized-promise"
   ],

--- a/src/simulation/automation-step-simulation.ts
+++ b/src/simulation/automation-step-simulation.ts
@@ -1,3 +1,4 @@
+import { JSONPath } from 'jsonpath-plus';
 import {
   ApiExecuteAutomationHook,
   ExecuteAutomationStep,
@@ -62,8 +63,6 @@ import { SleepSimulation } from './automation/sleep-simulation';
 import { UpdateVariableSimulation } from './automation/update-variable-simulation';
 import { WaitForResourceSimulation } from './automation/wait-for-resource-simulation';
 import { AutomationSimulationProps } from './simulation';
-// eslint-disable-next-line
-const jp = require('jsonpath');
 
 /**
  * The same interface as AutomationSimulationProps but all fields are required.
@@ -323,7 +322,7 @@ export class AutomationStepSimulation {
       }
       // I cannot explain the hack below. But it needs to be reformed into an object.
       const hackedResponse = JSON.parse(JSON.stringify(response));
-      const selectedResponse = jp.query(hackedResponse, declaredOutput.selector)[0];
+      const selectedResponse = JSONPath({ path: declaredOutput.selector, json: hackedResponse })[0];
       if (selectedResponse === undefined) {
         throw new Error(`Output ${declaredOutput.name} specified selector ${declaredOutput.selector} but not found in response ${JSON.stringify(response)}`);
       }

--- a/src/simulation/automation/assert-aws-resource-simulation.ts
+++ b/src/simulation/automation/assert-aws-resource-simulation.ts
@@ -1,8 +1,7 @@
+import { JSONPath } from 'jsonpath-plus';
 import { AssertAwsResourceStep } from '../../parent-steps/automation/assert-aws-resource-step';
 import { AutomationSimulationBase } from './automation-simulation-base';
 import { AwsApiSimulation, AwsInvocationSimulationProps } from './aws-api-simulation';
-// eslint-disable-next-line
-const jp = require('jsonpath');
 
 /**
  * AutomationStep implementation of aws:assertAwsResourceProperty.
@@ -47,7 +46,7 @@ export class AssertAwsResourceSimulation extends AutomationSimulationBase {
      */
   private parseSelectedOrNull(awsResult: {}) {
     try {
-      return jp.query(awsResult, this.assertStep.selector)[0];
+      return JSONPath({ path: this.assertStep.selector, json: awsResult })[0];
     } catch (error) {
       console.log('Error found when reading jsonpath: ' + error);
       return undefined;

--- a/test/parent-steps/automation/assert-aws-resource-step.test.ts
+++ b/test/parent-steps/automation/assert-aws-resource-step.test.ts
@@ -40,6 +40,24 @@ describe('AssertAwsResourceStep', function() {
       const response = new AutomationStepSimulation(step, { awsInvoker: mockInvoker }).invoke({ 'SomeOutput.OutKey': 'FilterVal' });
       assert.equal(response.responseCode, ResponseCode.FAILED);
     });
+    it('Passes when desired value found via recursive descent selector', function() {
+      const step = new AssertAwsResourceStep(new Stack(), 'id', {
+        name: 'MyEc2DescribeImages',
+        service: AwsService.EC2,
+        selector: '$.Images..State',
+        desiredValues: ['available'],
+        pascalCaseApi: 'DescribeImages',
+        apiParams: {},
+      });
+
+      const mockInvoker = new MockAwsInvoker();
+      mockInvoker.nextReturn({ Images: [{ State: 'available' }, { State: 'pending' }] });
+      const response = new AutomationStepSimulation(step, { awsInvoker: mockInvoker }).invoke({});
+      if (response.responseCode != ResponseCode.SUCCESS) {
+        assert.fail(response.stackTrace);
+      }
+      assert.equal(response.responseCode, ResponseCode.SUCCESS);
+    });
   });
   describe('#toSsmEntry()', function() {
     it('Builds entry as per SSM Document', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,6 +1017,16 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsep-plugin/assignment@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/assignment/-/assignment-1.3.0.tgz#fcfc5417a04933f7ceee786e8ab498aa3ce2b242"
+  integrity sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==
+
+"@jsep-plugin/regex@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
+  integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
+
 "@jsii/check-node@1.105.0":
   version "1.105.0"
   resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.105.0.tgz#92ffea17d1497ddf9b104088d65a363bbf9d2b64"
@@ -2725,7 +2735,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-escodegen@^2.0.0, escodegen@^2.1.0:
+escodegen@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz"
   integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
@@ -2859,11 +2869,6 @@ espree@^10.0.1, espree@^10.3.0, espree@^10.4.0:
     acorn "^8.15.0"
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^4.2.1"
-
-esprima@1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.5.tgz#0993502feaf668138325756f30f9a51feeec11e9"
-  integrity sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ==
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -4333,6 +4338,11 @@ jsdom@^16.6.0:
     ws "^7.4.6"
     xml-name-validator "^3.0.0"
 
+jsep@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.4.0.tgz#19feccbfa51d8a79f72480b4b8e40ce2e17152f0"
+  integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
+
 jsesc@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
@@ -4527,14 +4537,14 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonpath@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.3.0.tgz#623197970fb433845c68024bf9e2b864f5376ab2"
-  integrity sha512-0kjkYHJBkAy50Z5QzArZ7udmvxrJzkpKYW27fiF//BrMY7TQibYLl+FYIXN2BiYmwMIVzSfD8aDRj6IzgBX2/w==
+jsonpath-plus@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz#73cf545c231afda21452150b7a2a58e48e109702"
+  integrity sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==
   dependencies:
-    esprima "1.2.5"
-    static-eval "2.1.1"
-    underscore "1.13.6"
+    "@jsep-plugin/assignment" "^1.3.0"
+    "@jsep-plugin/regex" "^1.0.4"
+    jsep "^1.4.0"
 
 jsonschema@^1.5.0:
   version "1.5.0"
@@ -5846,13 +5856,6 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-static-eval@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.1.1.tgz#71ac6a13aa32b9e14c5b5f063c362176b0d584ba"
-  integrity sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==
-  dependencies:
-    escodegen "^2.1.0"
-
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
@@ -6302,11 +6305,6 @@ unbox-primitive@^1.1.0:
     has-bigints "^1.0.2"
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
-
-underscore@1.13.6:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
-  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
Hi friends,

I am part of the team mainiting the AWS Solution [Automated Security Response on AWS](https://github.com/aws-solutions/automated-security-response-on-aws), an we have an open `high` severity Dependabot finding due to our dependency on cdk-ssm-documents. I'd like to get that resolved with the attached change (migrating from the vulnerable `jsonpath` dependency to `jsonpath-plus`).

## Problem

`jsonpath@1.3.0` (a **bundled** dependency of cdk-ssm-documents) hard-pins `underscore@1.13.6`, which has a High-severity DoS advisory (**CVE-2026-27601** - DoS via recursive data structures in `flatten`/`isEqual`, fixed in `underscore@1.13.8`).

Because `jsonpath` is in `bundledDependencies`, the vulnerable `underscore` ships **inside the published tarball**, so downstream consumers of `@cdklabs/cdk-ssm-documents` cannot remediate it via npm `overrides` or `npm audit fix` - it surfaces as an unfixable High finding in their security scans.

Fixing it at the source is blocked: `jsonpath@1.3.0` is already the latest release and still hard-pins the vulnerable `underscore`, and the upstream fix in `dchester/jsonpath` ([#201](https://github.com/dchester/jsonpath/pull/201)) has been open with no maintainer response for months.

## Change

Migrate from `jsonpath` to [`jsonpath-plus`](https://www.npmjs.com/package/jsonpath-plus), which is actively maintained and depends on **neither `underscore` nor `static-eval`** - removing the vulnerable subtree entirely rather than patching one leaf.

Usage is limited to a single query API at two call sites under `src/simulation/`:

```ts
// before
const jp = require('jsonpath');
jp.query(obj, selector)[0];

// after
import { JSONPath } from 'jsonpath-plus';
JSONPath({ path: selector, json: obj })[0];
```

## Verification

- Confirmed query parity between `jsonpath` and `jsonpath-plus` for every selector pattern used in the codebase: simple property paths (`$.a.b`), indices (`$.a[0]`), recursive descent (`$.a..b`), and the missing-key -> `undefined` case.
- All selectors in the codebase are plain paths (no filter/script expressions), so `jsonpath-plus`'s eval-based features are never exercised.
- Added a unit test covering a recursive-descent selector (the syntax most likely to differ between implementations).
- `yarn compile` and `yarn test` pass locally (251 tests).

## Note

`jsonpath` was in `bundledDeps`; this PR swaps it for `jsonpath-plus` there via `.projenrc.ts` (projen-managed), so the fix propagates into the published bundle.
